### PR TITLE
Added JPEG support for output

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -28,6 +28,15 @@ resemble('People.jpg').compareTo('People2.jpg')
     data.getDiffImage().pack().pipe(fs.createWriteStream('diffjpg.png'));
   });
 
+// jpeg comparison
+resemble('People.jpg').compareTo('People2.jpg')
+  //.ignoreAntialiasing()
+  //.ignoreColors()
+  .onComplete(function(data){
+    console.log(data);
+    fs.writeFileSync('diffjpg.jpg', data.getDiffImageAsJPEG());
+  });
+
 var fileData1 = fs.readFileSync('People.png');
 var fileData2 = fs.readFileSync('People2.png');
 resemble(fileData1).compareTo(fileData2)

--- a/resemble.js
+++ b/resemble.js
@@ -430,6 +430,14 @@ var _this = {};
 			data.getDiffImage = function(text){
         return imgd;
 			};
+
+			data.getDiffImageAsJPEG = function(quality) {
+				return jpeg.encode({
+				  data: targetPix,
+				  width: img1.width,
+				  height: img1.height
+				}, quality !== undefined ? quality : 50).data;
+			};
 		}
 
 		function compare(one, two){


### PR DESCRIPTION
Recently JPEG support added as the input. This PR adds JPEG support to output also.
To preserve backward compatibility, a new method (`getDiffImageAsJPEG()`) added alongside `getDiffImage()`.

This new method returns data as a Node.js Buffer.
