### PR TITLE
pngjs package version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/lksv/node-resemble.js",
   "dependencies": {
-    "pngjs": "~2.2.0",
-    "jpeg-js": "0.2.0"
+    "jpeg-js": "0.2.0",
+    "pngjs": "^3.3.2"
   },
   "devDependencies": {
     "gulp": "3.9.0",


### PR DESCRIPTION
Hi

Thanks for the awesome package to compare image.

There are some missing updates in a package **pngjs** in file i.e _`/node_modules/node-resemble-js/node_modules/pngjs/lib/bitmapper.js file`_  and function **mapImage8Bit**

There are missing line of code in the previous version of package i.e
```
var idx = pixelBppMap[bpp][i];
        if (idx === 0xff) {
          pxData[pxPos + i] = 0xff;
        } else {
          var dataPos = idx + rawPos;
          if (dataPos === data.length) {
            throw new Error('Ran out of data');
          }
          pxData[pxPos + i] = data[dataPos];
        }
```

So we need to update the version of this package to resolved the issue in their previous releases.

So, I have updated the package pngjs in your package.json of node-resemble.js.Please update to resolve future issues.

Thanks

Regards
afzydev

